### PR TITLE
3.14 added + concurrency on coverage and zip

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,8 @@
 name: Coverage
 run-name: Coverage for ${{ github.sha }}
+concurrency:
+  group: coverage_and_zip_master
+  cancel-in-progress: false
 on:
   push:
     branches:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
       - name: Install uv with Python version ${{ matrix.python-version }}

--- a/.github/workflows/zip_source.yml
+++ b/.github/workflows/zip_source.yml
@@ -1,5 +1,8 @@
 name: Zip source code
 run-name: Zip source code for ${{ github.sha }}
+concurrency:
+  group: coverage_and_zip_master
+  cancel-in-progress: false
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary by Sourcery

Add concurrency to coverage and zip workflows and extend unittest CI to include Python 3.14

CI:
- Add a shared concurrency group to the coverage workflow to coordinate runs
- Add a shared concurrency group to the zip source workflow to coordinate runs
- Extend the unittest workflow matrix to test against Python 3.14